### PR TITLE
Adds parsing and memorialization of scope specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ p8e gradle plugin allows for publishing p8e Contracts against a [p8e](https://gi
 
 
 WARNING: Versions prior to `1.0.0` should be considered unstable and API changes expected.
+WARNING: This plugin targets [provenance 0.40.0](https://github.com/provenance-io/provenance) and thus only builds on p8e supported branches for the time being.
 
 ## Overview
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
 
     implementation("org.reflections:reflections:0.9.10")
 
-    implementation("io.provenance.p8e:p8e-sdk:0.6.0-scopespec-beta.1")
+    implementation("io.provenance.p8e:p8e-sdk:0.6.0-scopespec-beta.4")
     // implementation("io.provenance.p8e:p8e-sdk:1.0-SNAPSHOT")
 
     implementation("commons-io:commons-io:2.8.0")

--- a/example/contracts/src/main/kotlin/io/p8e/contracts/example/HelloWorld.kt
+++ b/example/contracts/src/main/kotlin/io/p8e/contracts/example/HelloWorld.kt
@@ -5,10 +5,12 @@ import io.p8e.annotations.Function
 import io.p8e.annotations.Input
 import io.p8e.annotations.Participants
 import io.p8e.annotations.ScopeSpecification
+import io.p8e.annotations.ScopeSpecificationDefinition
 import io.p8e.proto.ContractScope.Scope
 import io.p8e.proto.ContractSpecs.PartyType.*
 import io.p8e.proto.example.HelloWorldExample.ExampleName
 import io.p8e.spec.P8eContract
+import io.p8e.spec.P8eScopeSpecification
 
 @Participants(roles = [OWNER])
 @ScopeSpecification(names = ["io.p8e.contracts.example.helloWorld"])
@@ -22,5 +24,11 @@ open class HelloWorldContract(): P8eContract() {
             .build()
 }
 
+@ScopeSpecificationDefinition(
+    name = "io.p8e.contracts.example.helloWorld",
+    description = "A generic scope that allows for a lot of example hello world contracts.",
+    partiesInvolved = [OWNER],
+)
+open class HelloWorldScopeSpecification() : P8eScopeSpecification()
 
 data class HelloWorldData(@Fact(name = "name") val name: ExampleName, val scope: Scope) {}

--- a/src/main/kotlin/io/provenance/p8e/plugin/Utils.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Utils.kt
@@ -21,6 +21,9 @@ fun getJar(project: Project, taskName: String = "jar"): File {
         ?: throw IllegalStateException("task :$taskName in ${project.name} could not be found")
 }
 
+fun findScopes(classLoader: ClassLoader): Set<Class<out io.p8e.spec.P8eScopeSpecification>> =
+    findClasses(io.p8e.spec.P8eScopeSpecification::class.java, classLoader)
+
 fun findContracts(classLoader: ClassLoader): Set<Class<out io.p8e.spec.P8eContract>> =
     findClasses(io.p8e.spec.P8eContract::class.java, classLoader)
 


### PR DESCRIPTION
## Description

Contract specification memorialization needs to support the provenance blockchain concept of scope specifications. This is needed in order to memorialize contracts on 0.40.0 testnet. Makes use of new p8e annotations that are checked and bootstrapped accordingly.

