### PR TITLE
Pulls p8e-sdk deps from maven central instead of github maven.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,14 +21,6 @@ repositories {
     mavenCentral()
     maven { url = uri("https://javadoc.jitpack.io") }
     maven { url = uri("https://plugins.gradle.org/m2/") }
-    maven {
-        name = "GitHubPackages"
-        url = uri("https://maven.pkg.github.com/provenance-io/p8e")
-        credentials {
-            username = System.getenv("GITHUB_ACTOR")
-            password = System.getenv("GITHUB_TOKEN")
-        }
-    }
 }
 
 val integrationTest: SourceSet by sourceSets.creating {
@@ -47,7 +39,7 @@ dependencies {
 
     implementation("org.reflections:reflections:0.9.10")
 
-    implementation("io.provenance.p8e:p8e-sdk:0.6.0-testnet-1")
+    implementation("io.provenance.p8e:p8e-sdk:0.7.3")
     // implementation("io.provenance.p8e:p8e-sdk:1.0-SNAPSHOT")
 
     implementation("commons-io:commons-io:2.8.0")

--- a/example-java/build.gradle
+++ b/example-java/build.gradle
@@ -4,14 +4,6 @@ buildscript {
         jcenter()
         mavenCentral()
         maven { url 'https://javadoc.jitpack.io' }
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/provenance-io/p8e")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 
     dependencies {
@@ -20,7 +12,7 @@ buildscript {
 }
 
 plugins {
-    id "io.provenance.p8e.p8e-publish" version "0.4.0"
+    id "io.provenance.p8e.p8e-publish" version "0.4.1"
     // id "io.provenance.p8e.p8e-publish" version "1.0-SNAPSHOT"
 }
 
@@ -33,14 +25,6 @@ allprojects {
         jcenter()
         mavenCentral()
         maven { url 'https://javadoc.jitpack.io' }
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/provenance-io/p8e")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 }
 

--- a/example-java/contracts/build.gradle
+++ b/example-java/contracts/build.gradle
@@ -13,7 +13,7 @@ plugins {
 dependencies {
     api project(':protos')
 
-    implementation("io.provenance.p8e:p8e-contract-base:0.6.0-public-release-beta.1")
+    implementation("io.provenance.p8e:p8e-contract-base:0.7.3")
     // implementation("io.provenance.p8e:p8e-contract-base:1.0-SNAPSHOT")
 }
 

--- a/example-java/protos/build.gradle
+++ b/example-java/protos/build.gradle
@@ -23,7 +23,7 @@ plugins {
 sourceSets.main.java.srcDirs += 'build/generated/source/proto/main/java'
 
 dependencies {
-    implementation("io.provenance.p8e:p8e-contract-base:0.6.0-public-release-beta.1")
+    implementation("io.provenance.p8e:p8e-contract-base:0.7.3")
     // implementation("io.provenance.p8e:p8e-contract-base:1.0-SNAPSHOT")
 
     compile "com.google.protobuf:protobuf-java:$protobuf_version"

--- a/example-java/runner/build.gradle
+++ b/example-java/runner/build.gradle
@@ -13,7 +13,7 @@ dependencies{
     implementation project(":contracts")
     implementation project(":protos")
 
-    implementation "io.provenance.p8e:p8e-sdk:0.6.0-testnet-1"
+    implementation "io.provenance.p8e:p8e-sdk:0.7.3"
     // implementation "io.provenance.p8e:p8e-sdk:1.0-SNAPSHOT"
     implementation "ch.qos.logback:logback-classic:1.2.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32"

--- a/example-java/runner/src/main/java/Runner.java
+++ b/example-java/runner/src/main/java/Runner.java
@@ -48,7 +48,7 @@ public class Runner {
             return true;
         };
 
-        ContractManager cm = ContractManager.Companion.create(key, p8eUrl);
+        ContractManager cm = ContractManager.Companion.create(key, p8eUrl, 60_000);
         cm.watchBuilder(HelloWorldJavaContract.class)
                 .stepCompletion(completeHandler)
                 .error(errorHandler)

--- a/example-kotlin/build.gradle
+++ b/example-kotlin/build.gradle
@@ -4,14 +4,6 @@ buildscript {
         jcenter()
         mavenCentral()
         maven { url 'https://javadoc.jitpack.io' }
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/provenance-io/p8e")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 
     dependencies {
@@ -21,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id "io.provenance.p8e.p8e-publish" version "0.4.0"
+    id "io.provenance.p8e.p8e-publish" version "0.4.1"
     // id "io.provenance.p8e.p8e-publish" version "1.0-SNAPSHOT"
 }
 
@@ -34,14 +26,6 @@ allprojects {
         jcenter()
         mavenCentral()
         maven { url 'https://javadoc.jitpack.io' }
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/provenance-io/p8e")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 }
 

--- a/example-kotlin/contracts/build.gradle
+++ b/example-kotlin/contracts/build.gradle
@@ -13,7 +13,7 @@ plugins {
 dependencies {
     api project(':protos')
 
-    implementation("io.provenance.p8e:p8e-contract-base:0.6.0-public-release-beta.1")
+    implementation("io.provenance.p8e:p8e-contract-base:0.7.3")
     // implementation("io.provenance.p8e:p8e-contract-base:1.0-SNAPSHOT")
 }
 

--- a/example-kotlin/protos/build.gradle
+++ b/example-kotlin/protos/build.gradle
@@ -23,7 +23,7 @@ sourceSets.main.java.srcDirs += 'build/generated/source/proto/main/java'
 sourceSets.main.java.srcDirs += 'src/main/kotlin'
 
 dependencies {
-    implementation("io.provenance.p8e:p8e-contract-base:0.6.0-public-release-beta.1")
+    implementation("io.provenance.p8e:p8e-contract-base:0.7.3")
     // implementation("io.provenance.p8e:p8e-contract-base:1.0-SNAPSHOT")
 
     compile "com.google.protobuf:protobuf-java:$protobuf_version"

--- a/example-kotlin/runner/build.gradle
+++ b/example-kotlin/runner/build.gradle
@@ -18,7 +18,7 @@ dependencies{
     implementation project(":contracts")
     implementation project(":protos")
 
-    implementation "io.provenance.p8e:p8e-sdk:0.6.0-testnet-1"
+    implementation "io.provenance.p8e:p8e-sdk:0.7.3"
     // implementation "io.provenance.p8e:p8e-sdk:1.0-SNAPSHOT"
     implementation "ch.qos.logback:logback-classic:1.2.3"
 }


### PR DESCRIPTION
## Description

Rather than configuring github credentials in order to pull the p8e-sdk jars, they were moved to maven central. This PR puts this repo in line with those new versions.
