### PR TITLE
add interfaces that contracts are using/implementing to ContractHash service provider contracts list

### DIFF
--- a/src/main/kotlin/io/provenance/p8e/plugin/ServiceProvider.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/ServiceProvider.kt
@@ -80,6 +80,8 @@ object ServiceProvider {
             .writeText(contractHashServiceContent)
     }
 
+    private fun Set<Class<out P8eContract>>.withInterfaces() = this + this.flatMap { it.interfaces.toList() }.toSet()
+
     fun getContractHashContent(
         projectPaths: ProjectPaths,
         extension: P8eExtension,
@@ -95,7 +97,7 @@ import io.provenance.scope.contract.contracts.ContractHash
 class ContractHash$uid : ContractHash {
 
     private val classes = ${
-                contracts.map { it.name.replace("\$", "\\$") }
+                contracts.withInterfaces().map { it.name.replace("\$", "\\$") }
                     .map { "\"$it\" to true" }
                     .joinToString(separator = ", ", prefix = "mapOf(", postfix = ")")
             }
@@ -125,7 +127,7 @@ public class ContractHash$uid implements ContractHash {
 
     private final Map<String, Boolean> classes = new HashMap<String, Boolean>() {{
         ${
-            contracts.map { it.name }
+            contracts.withInterfaces().map { it.name }
                 .map { "put(\"$it\", true);" }
                 .joinToString(separator = "\n")
         }


### PR DESCRIPTION
- prevents weird ClassLoader linkage errors where methods in the interface would be defined in the app ClassLoader, but arguments to those methods might be loaded in the child ClassLoader
- los-p8e-contracts [uses interfaces to define shared functions between contracts](https://github.com/FigureTechnologies/los-p8e-contracts/blob/develop/contract/src/main/kotlin/com/figure/los/contract/origination/Onboard.kt#L176), but the interface was not listed in the ContractHash contracts list, so it would be loaded by the parent class loader in the p8e-scope, but the arguments to the function it provides would be in the child class loader, leading to a LinkageError like `java.lang.RuntimeException: loader constraint violation: loader 'MemoryClassLoader' @7dcb9a94 wants to load class io.p8e.proto.Common$BooleanResult. A different class with the same name was previously loaded by 'app'. (io.p8e.proto.Common$BooleanResult is in unnamed module of loader 'app')`. This change informs the MemoryClassLoader to load the interface from the object store jar as well as the rest of the classes