### PR TITLE
Configurable package search paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ p8e {
     // Package locations that the ContractHash and ProtoHash source files will be written to.
     contractHashPackage = "io.p8e.contracts.example"
     protoHashPackage = "io.p8e.proto.example"
-
+    
+    // Specifies the root packages to search in when building contractHash and protoHash classes. Defaults to ["io", "com"]
+    includePackages = ["io", "com"]
+    
     // specifies all of the p8e locations that this plugin will bootstrap to.
     locations = [
         local: new io.provenance.p8e.plugin.P8eLocationExtension(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,9 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.12.2")
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.12.2")
 
-    testImplementation("io.kotest:kotest-runner-junit5:4.4.+")
+    testImplementation("io.kotest:kotest-runner-junit5:5.2.+")
+    testImplementation("io.kotest:kotest-assertions-core:5.2.+")
+    testImplementation("io.kotest:kotest-property:5.2.+")
     "integrationTestImplementation"("io.kotest:kotest-runner-junit5:4.4.+")
 }
 

--- a/example-kotlin/build.gradle
+++ b/example-kotlin/build.gradle
@@ -37,16 +37,18 @@ p8e {
     language = "kt" // defaults to "java"
     contractHashPackage = "io.p8e.contracts.examplekotlin"
     protoHashPackage = "io.p8e.proto.examplekotlin"
+    includePackages = ["io", "com", "tech"]
 
     // specifies all of the p8e locations that this plugin will bootstrap to.
     locations = [
         local: new io.provenance.p8e.plugin.P8eLocationExtension(
-            osUrl: System.getenv('OS_GRPC_URL'),
-            provenanceUrl: System.getenv('PROVENANCE_GRPC_URL'),
-            encryptionPrivateKey: System.getenv('ENCRYPTION_PRIVATE_KEY'),
-            signingPrivateKey: System.getenv('SIGNING_PRIVATE_KEY'),
-            chainId: System.getenv('CHAIN_ID'),
+            osUrl: 'grpc://localhost:5001',
+            provenanceUrl: 'grpc://localhost:9090',
+            encryptionPrivateKey: '0A2100EF4A9391903BFE252CB240DA6695BC5F680A74A8E16BEBA003833DFE9B18C147',
+            signingPrivateKey: '0A2100EF4A9391903BFE252CB240DA6695BC5F680A74A8E16BEBA003833DFE9B18C147',
+            chainId: 'chain-local',
             txBatchSize: "10",
+            txFeeAdjustment: "2.0",
 
             audience: [
                 local1: new io.provenance.p8e.plugin.P8ePartyExtension(

--- a/example-kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/example-kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/provenance/p8e/plugin/Bootstrapper.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Bootstrapper.kt
@@ -118,9 +118,9 @@ internal class Bootstrapper(
         val contractJar = getJar(contractProject, "shadowJar")
         val protoJar = getJar(protoProject)
         val contractClassLoader = URLClassLoader(arrayOf(contractJar.toURI().toURL()), javaClass.classLoader)
-        val contracts = findContracts(contractClassLoader)
-        val scopes = findScopes(contractClassLoader)
-        val protos = findProtos(contractClassLoader)
+        val contracts = findContracts(contractClassLoader, extension.includePackages)
+        val scopes = findScopes(contractClassLoader, extension.includePackages)
+        val protos = findProtos(contractClassLoader, extension.includePackages)
 
         var errored = false
 

--- a/src/main/kotlin/io/provenance/p8e/plugin/Checker.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Checker.kt
@@ -28,7 +28,7 @@ internal class Checker(
         val contractJar = getJar(contractProject, "shadowJar")
         val contractClassLoader = URLClassLoader(arrayOf(contractJar.toURI().toURL()), javaClass.classLoader)
 
-        val scopeDefinitions = findScopes(contractClassLoader).map { clazz ->
+        val scopeDefinitions = findScopes(contractClassLoader, extension.includePackages).map { clazz ->
             project.logger.info("Found ${clazz.name}")
 
             val definitions = clazz.annotations
@@ -59,7 +59,7 @@ internal class Checker(
             }
         }
 
-        findContracts(contractClassLoader).forEach { clazz ->
+        findContracts(contractClassLoader, extension.includePackages).forEach { clazz ->
             project.logger.info("Checking ${clazz.name}")
 
             val spec = ContractSpecMapper.dehydrateSpec(

--- a/src/main/kotlin/io/provenance/p8e/plugin/Dsl.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Dsl.kt
@@ -24,6 +24,7 @@ open class P8eExtension {
     // TODO what is a good default package path that is somehow derived from the current project?
     var contractHashPackage: String = ""
     var protoHashPackage: String = ""
+    var includePackages: Array<String> = arrayOf("io", "com")
     var language: String = "java"
     var locations: Map<String, P8eLocationExtension> = emptyMap()
 }

--- a/src/main/kotlin/io/provenance/p8e/plugin/Utils.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Utils.kt
@@ -23,15 +23,15 @@ fun getJar(project: Project, taskName: String = "jar"): File {
         ?: throw IllegalStateException("task :$taskName in ${project.name} could not be found")
 }
 
-fun findScopes(classLoader: ClassLoader): Set<Class<out P8eScopeSpecification>> =
-    findClasses(P8eScopeSpecification::class.java, classLoader)
+fun findScopes(classLoader: ClassLoader, includePackages: Array<String>): Set<Class<out P8eScopeSpecification>> =
+    findClasses(P8eScopeSpecification::class.java, classLoader, includePackages)
 
-fun findContracts(classLoader: ClassLoader): Set<Class<out P8eContract>> =
-    findClasses(P8eContract::class.java, classLoader)
+fun findContracts(classLoader: ClassLoader, includePackages: Array<String>): Set<Class<out P8eContract>> =
+    findClasses(P8eContract::class.java, classLoader, includePackages)
 
-fun findProtos(classLoader: ClassLoader): Set<Class<out com.google.protobuf.Message>> =
-    findClasses(com.google.protobuf.Message::class.java, classLoader)
+fun findProtos(classLoader: ClassLoader, includePackages: Array<String>): Set<Class<out com.google.protobuf.Message>> =
+    findClasses(com.google.protobuf.Message::class.java, classLoader, includePackages)
 
-fun<T> findClasses(clazz: Class<T>, classLoader: ClassLoader): Set<Class<out T>> =
-    Reflections("io", "com", SubTypesScanner(false), classLoader)
+fun<T> findClasses(clazz: Class<T>, classLoader: ClassLoader, includePackages: Array<String>): Set<Class<out T>> =
+    Reflections(includePackages, SubTypesScanner(false), classLoader)
         .getSubTypesOf(clazz)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Found an issue where the plugin defaults to searching for protos / contracts / scopes within packages with prefixes = "io", "com". After needing to introduce contracts following the [new metadata model](https://github.com/provenance-io/metadata-asset-model), the following error occurs: 

```
Unable to find ProtoHash instance to match tech.figure.asset.v1beta1.Asset, 
please verify you are running a Provenance bootstrapped JAR.
```
Adding the ability to specify package prefixes directly in the p8e block config such that `tech.figure` can be included and properly build the ProtoHash file with the needed definitions. 