### PR TITLE
Adding support to update optional headers for the grpc connection to object store.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ p8e {
             encryptionPrivateKey: System.getenv('ENCRYPTION_PRIVATE_KEY'),
             signingPrivateKey: System.getenv('SIGNING_PRIVATE_KEY'),
             txBatchSize: "10",
+            osHeaders: [
+                "apiKey" to "some awesome API key"
+            ],
 
             audience: [
                 local1: new io.provenance.p8e.plugin.P8ePartyExtension(

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ p8e {
             signingPrivateKey: System.getenv('SIGNING_PRIVATE_KEY'),
             txBatchSize: "10",
             osHeaders: [
-                "apiKey" to "some awesome API key"
+                // optional object store grpc headers here
             ],
 
             audience: [

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,8 +38,8 @@ dependencies {
 
     implementation("org.reflections:reflections:0.9.10")
 
-    implementation("io.provenance.scope:sdk:0.4.0")
-    implementation("io.provenance.scope:util:0.4.0")
+    implementation("io.provenance.scope:sdk:0.5.1")
+    implementation("io.provenance.scope:util:0.5.1")
     implementation("io.provenance.protobuf:pb-proto-java:1.5.0")
 
     implementation("io.grpc:grpc-protobuf:1.39.0")

--- a/src/main/kotlin/io/provenance/p8e/plugin/Bootstrapper.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Bootstrapper.kt
@@ -131,12 +131,12 @@ internal class Bootstrapper(
                 cacheJarSizeInBytes = 0L,
                 cacheSpecSizeInBytes = 0L,
                 cacheRecordSizeInBytes = 0L,
-
                 osGrpcUrl = URI(location.osUrl!!),
                 osGrpcDeadlineMs = 60 * 1_000L,
-
                 mainNet = location.mainNet,
+                extraHeaders = location.osHeaders,
             )
+
             val encryptionKeyPair = getKeyPair(location.encryptionPrivateKey!!)
             val signingKeyPair = getKeyPair(location.signingPrivateKey!!)
             val pbSigner = signingKeyPair.toSignerMeta()

--- a/src/main/kotlin/io/provenance/p8e/plugin/Dsl.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Dsl.kt
@@ -16,6 +16,7 @@ open class P8eLocationExtension {
     var mainNet: Boolean = chainId == "pio-mainnet-1"
     var txBatchSize: String = "10"
     var txFeeAdjustment: String = "1.25"
+    var osHeaders: Map<String, String> = emptyMap()
 }
 
 open class P8eExtension {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Adding support to update optional headers for the grpc connection to object store. This is primarily to allow for an api key to be specified such that the `p8e-cee-api` can hit the figure object store. 

