### PR TITLE
make gas price configurable per location

### DIFF
--- a/src/main/kotlin/io/provenance/p8e/plugin/Dsl.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Dsl.kt
@@ -16,6 +16,7 @@ open class P8eLocationExtension {
     var mainNet: Boolean = chainId == "pio-mainnet-1"
     var txBatchSize: String = "10"
     var txFeeAdjustment: String = "1.25"
+    var txGasPrice: String? = ""
     var osHeaders: Map<String, String> = emptyMap()
 }
 


### PR DESCRIPTION
ultimately this should be changed to all use https://github.com/provenance-io/pb-grpc-client-kotlin/ and the gas price options there, but this should allow configuring for pio-testnet-1's new 19050 floor gas price

closes: #XXXX
