### PR TITLE
use shared channel for PbClient to allow for proper shutdown

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "1.9.10"
 reflections = "0.9.10"
 provenance-scope-sdk = "0.7.0-rc2"
-provenance-client = "2.4.0-rc1"
+provenance-client = "2.4.0"
 provenance-protobuf = "1.5.0"
 figure-hdwallet = "0.4.3"
 grpc = "1.58.0"

--- a/src/main/kotlin/io/provenance/p8e/plugin/Bootstrapper.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/Bootstrapper.kt
@@ -4,6 +4,8 @@ import com.google.protobuf.ByteString
 import com.google.protobuf.Message
 import io.grpc.ManagedChannelBuilder
 import io.provenance.client.grpc.BaseReqSigner
+import io.provenance.client.grpc.ChannelOpts
+import io.provenance.client.grpc.createChannel
 import io.provenance.metadata.v1.ContractSpecification
 import io.provenance.metadata.v1.ContractSpecificationRequest
 import io.provenance.metadata.v1.DefinitionType
@@ -149,10 +151,7 @@ internal class Bootstrapper(
             )
             val sdk = Client(SharedClient(config), affiliate)
             val provenanceUri = URI(location.provenanceUrl!!)
-            val channel = ManagedChannelBuilder
-                .forAddress(provenanceUri.host, provenanceUri.port)
-                .usePlaintext()
-                .build()
+            val channel = createChannel(provenanceUri, ChannelOpts()) { }
             val client = ProvenanceClient(channel, project.logger, location)
 
             try {

--- a/src/main/kotlin/io/provenance/p8e/plugin/ProvenanceClient.kt
+++ b/src/main/kotlin/io/provenance/p8e/plugin/ProvenanceClient.kt
@@ -65,7 +65,8 @@ class ProvenanceClient(channel: ManagedChannel, val logger: Logger, val location
                 location.txGasPrice?.takeIf{ gasPriceString -> gasPriceString.isNotBlank() }?.toDouble()?.toCoin("nhash")?.also { logger.info("Using provided gas price of ${it.amount}${it.denom}") } ?:
                 CoinOuterClass.Coin.newBuilder().setAmount("19050").setDenom("nhash").build().also { logger.info("Using default gas price of ${it.amount}${it.denom}") }
             )
-        )
+        ),
+        channel = channel
     )
 
     fun scopeSpecification(request: ScopeSpecificationRequest): ScopeSpecificationResponse =


### PR DESCRIPTION
- channel generated from same utility used by PbClient internally
